### PR TITLE
Allowed passing paint by ref and by value. Removed the need for cloning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ unicode-segmentation = "1.6.0"
 generational-arena = "0.2.8"
 lru = { version = "0.7.1", default-features = false }
 image = { version = "0.24.0", optional = true, default-features = false }
-serde = { version = "1.0", optional = true, features = ["derive"] }
+serde = { version = "1.0", optional = true, features = ["derive", "rc"] }
 ouroboros = { version = "0.15" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/examples/breakout.rs
+++ b/examples/breakout.rs
@@ -544,7 +544,7 @@ impl Game {
         paint.set_font_size(80.0);
 
         paint.set_line_width(4.0);
-        let _ = canvas.stroke_text(canvas.width() / 2.0, canvas.height() / 2.0, "rsBREAKOUT", paint);
+        let _ = canvas.stroke_text(canvas.width() / 2.0, canvas.height() / 2.0, "rsBREAKOUT", paint.clone());
 
         paint.set_color(Color::rgb(143, 80, 49));
         let _ = canvas.fill_text(canvas.width() / 2.0, canvas.height() / 2.0, "rsBREAKOUT", paint);
@@ -593,7 +593,7 @@ impl Game {
             0.0,
         );
         canvas.fill_path(&mut path, Paint::color(Color::rgb(119, 123, 126)));
-        canvas.stroke_path(&mut path, highlight);
+        canvas.stroke_path(&mut path, highlight.clone());
 
         let mut path = Path::new();
         path.rect(
@@ -603,7 +603,7 @@ impl Game {
             self.paddle_rect.size.height,
         );
         canvas.fill_path(&mut path, Paint::color(Color::rgb(119, 123, 126)));
-        canvas.stroke_path(&mut path, highlight);
+        canvas.stroke_path(&mut path, highlight.clone());
 
         let mut path = Path::new();
         path.rounded_rect_varying(
@@ -710,7 +710,12 @@ impl Game {
         let offset = 30.0;
 
         paint.set_line_width(4.0);
-        let _ = canvas.stroke_text(canvas.width() / 2.0, (canvas.height() / 2.0) + offset, heading, paint);
+        let _ = canvas.stroke_text(
+            canvas.width() / 2.0,
+            (canvas.height() / 2.0) + offset,
+            heading,
+            paint.clone(),
+        );
 
         paint.set_color(Color::rgb(143, 80, 49));
         let _ = canvas.fill_text(canvas.width() / 2.0, (canvas.height() / 2.0) + offset, heading, paint);

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -411,10 +411,12 @@ fn draw_paragraph<T: Renderer>(
     let mut px;
     let mut caret_x;
 
-    let lines = canvas.break_text_vec(width, text, paint).expect("Cannot break text");
+    let lines = canvas
+        .break_text_vec(width, text, paint.clone())
+        .expect("Cannot break text");
 
     for (line_num, line_range) in lines.into_iter().enumerate() {
-        if let Ok(res) = canvas.fill_text(x, y, &text[line_range], paint) {
+        if let Ok(res) = canvas.fill_text(x, y, &text[line_range], paint.clone()) {
             let hit = mx > x && mx < (x + width) && my >= y && my < (y + res.height());
 
             if hit {
@@ -455,7 +457,7 @@ fn draw_paragraph<T: Renderer>(
 
         let text = format!("{}", gutter);
 
-        if let Ok(res) = canvas.measure_text(x - 10.0, gutter_y, &text, paint) {
+        if let Ok(res) = canvas.measure_text(x - 10.0, gutter_y, &text, paint.clone()) {
             let mut path = Path::new();
             path.rounded_rect(
                 res.x - 4.0,
@@ -464,7 +466,7 @@ fn draw_paragraph<T: Renderer>(
                 res.height() + 4.0,
                 (res.height() + 4.0) / 2.0 - 1.0,
             );
-            canvas.fill_path(&mut path, paint);
+            canvas.fill_path(&mut path, paint.clone());
 
             paint.set_color(Color::rgba(32, 32, 32, 255));
             let _ = canvas.fill_text(x - 10.0, gutter_y, &text, paint);
@@ -714,7 +716,7 @@ fn draw_window<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, title: &str, 
 
     let _ = canvas.fill_text(x + (w / 2.0), y + 19.0, title, text_paint);
 
-    // let bounds = canvas.text_bounds(x + (w / 2.0), y + 19.0, title, text_paint);
+    // let bounds = canvas.text_bounds(x + (w / 2.0), y + 19.0, title, &text_paint);
     //
     // let mut path = Path::new();
     // path.rect(bounds[0], bounds[1], bounds[2] - bounds[0], bounds[3] - bounds[1]);
@@ -974,8 +976,8 @@ fn draw_edit_box_num<T: Renderer>(
     paint.set_text_align(Align::Right);
     paint.set_text_baseline(Baseline::Middle);
 
-    if let Ok(layout) = canvas.measure_text(0.0, 0.0, units, paint) {
-        let _ = canvas.fill_text(x + w - h * 0.3, y + h * 0.5, units, paint);
+    if let Ok(layout) = canvas.measure_text(0.0, 0.0, units, paint.clone()) {
+        let _ = canvas.fill_text(x + w - h * 0.3, y + h * 0.5, units, paint.clone());
 
         paint.set_font_size(16.0);
         paint.set_color(Color::rgba(255, 255, 255, 128));
@@ -1050,7 +1052,7 @@ fn draw_button<T: Renderer>(
     paint.set_text_align(Align::Left);
     paint.set_text_baseline(Baseline::Middle);
 
-    let tw = if let Ok(layout) = canvas.measure_text(0.0, 0.0, text, paint) {
+    let tw = if let Ok(layout) = canvas.measure_text(0.0, 0.0, text, paint.clone()) {
         layout.width()
     } else {
         0.0
@@ -1062,17 +1064,22 @@ fn draw_button<T: Renderer>(
         paint.set_font(&[fonts.icons]);
         paint.set_font_size(h * 1.3);
 
-        if let Ok(layout) = canvas.measure_text(0.0, 0.0, icon, paint) {
+        if let Ok(layout) = canvas.measure_text(0.0, 0.0, icon, paint.clone()) {
             iw = layout.width() + (h * 0.15);
         }
 
-        let _ = canvas.fill_text(x + w * 0.5 - tw * 0.5 - iw * 0.75, y + h * 0.5, icon, paint);
+        let _ = canvas.fill_text(x + w * 0.5 - tw * 0.5 - iw * 0.75, y + h * 0.5, icon, paint.clone());
     }
 
     paint.set_font_size(15.0);
     paint.set_font(&[fonts.regular]);
     paint.set_color(Color::rgba(0, 0, 0, 160));
-    let _ = canvas.fill_text(x + w * 0.5 - tw * 0.5 + iw * 0.25, y + h * 0.5 - 1.0, text, paint);
+    let _ = canvas.fill_text(
+        x + w * 0.5 - tw * 0.5 + iw * 0.25,
+        y + h * 0.5 - 1.0,
+        text,
+        paint.clone(),
+    );
     paint.set_color(Color::rgba(255, 255, 255, 160));
     let _ = canvas.fill_text(x + w * 0.5 - tw * 0.5 + iw * 0.25, y + h * 0.5, text, paint);
 }
@@ -1338,7 +1345,7 @@ fn draw_lines<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, w: f32, _h: f
             path.line_to(fx + pts[2], fy + pts[3]);
             path.line_to(fx + pts[4], fy + pts[5]);
             path.line_to(fx + pts[6], fy + pts[7]);
-            canvas.stroke_path(&mut path, paint);
+            canvas.stroke_path(&mut path, paint.clone());
 
             paint.set_line_cap(LineCap::Butt);
             paint.set_line_join(LineJoin::Bevel);
@@ -1403,10 +1410,9 @@ fn draw_fills<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, mousex: f32, 
 fn draw_widths<T: Renderer>(canvas: &mut Canvas<T>, x: f32, mut y: f32, width: f32) {
     canvas.save();
 
-    let mut paint = Paint::color(Color::rgba(0, 0, 0, 255));
-
     for i in 0..20 {
         let w = (i as f32 + 0.5) * 0.1;
+        let mut paint = Paint::color(Color::rgba(0, 0, 0, 255));
         paint.set_line_width(w);
         let mut path = Path::new();
         path.move_to(x, y);
@@ -1436,6 +1442,7 @@ fn draw_caps<T: Renderer>(canvas: &mut Canvas<T>, x: f32, y: f32, width: f32) {
     paint.set_line_width(line_width);
 
     for (i, cap) in caps.iter().enumerate() {
+        let mut paint = paint.clone();
         paint.set_line_cap(*cap);
         let mut path = Path::new();
         path.move_to(x, y + i as f32 * 10.0 + 5.0);

--- a/examples/gradients.rs
+++ b/examples/gradients.rs
@@ -367,7 +367,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             0.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 255)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 255)),
@@ -384,7 +384,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             0.0,
             100.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 255)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 255)),
@@ -401,7 +401,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             100.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 255)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 255)),
@@ -419,7 +419,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             0.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 128)),
                 (0.5, Color::rgba(0, 255, 0, 128)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -436,7 +436,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             0.0,
             100.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 128)),
                 (0.5, Color::rgba(0, 255, 0, 128)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -453,7 +453,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             100.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 128)),
                 (0.5, Color::rgba(0, 255, 0, 128)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -471,7 +471,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             0.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 0)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -488,7 +488,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             0.0,
             100.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 0)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -505,7 +505,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             100.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 0)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -524,7 +524,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             50.0,
             0.0,
             50.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 255)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 255)),
@@ -541,7 +541,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             0.0,
             100.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 255)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 255)),
@@ -558,7 +558,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             50.0,
             25.0,
             75.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 255)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 255)),
@@ -576,7 +576,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             50.0,
             0.0,
             50.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 128)),
                 (0.5, Color::rgba(0, 255, 0, 128)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -593,7 +593,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             0.0,
             100.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 128)),
                 (0.5, Color::rgba(0, 255, 0, 128)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -610,7 +610,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             50.0,
             25.0,
             75.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 128)),
                 (0.5, Color::rgba(0, 255, 0, 128)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -628,7 +628,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             50.0,
             0.0,
             50.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 0)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -645,7 +645,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             0.0,
             100.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 0)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -662,7 +662,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             50.0,
             25.0,
             75.0,
-            &[
+            [
                 (0.0, Color::rgba(255, 0, 0, 0)),
                 (0.5, Color::rgba(0, 255, 0, 255)),
                 (1.0, Color::rgba(0, 0, 255, 128)),
@@ -682,7 +682,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             0.0,
-            &[(0.5, Color::rgba(255, 0, 0, 255)), (1.0, Color::rgba(0, 0, 255, 255))],
+            [(0.5, Color::rgba(255, 0, 0, 255)), (1.0, Color::rgba(0, 0, 255, 255))],
         ),
     );
     x += 110.0;
@@ -695,7 +695,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             0.0,
-            &[(0.4, Color::rgba(255, 0, 0, 255)), (0.6, Color::rgba(0, 0, 255, 255))],
+            [(0.4, Color::rgba(255, 0, 0, 255)), (0.6, Color::rgba(0, 0, 255, 255))],
         ),
     );
     x += 110.0;
@@ -708,7 +708,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             0.0,
-            &[(0.0, Color::rgba(255, 0, 0, 255)), (0.5, Color::rgba(0, 0, 255, 255))],
+            [(0.0, Color::rgba(255, 0, 0, 255)), (0.5, Color::rgba(0, 0, 255, 255))],
         ),
     );
     x += 110.0;
@@ -721,7 +721,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             0.0,
-            &[(0.5, Color::rgba(255, 0, 0, 255)), (0.5, Color::rgba(0, 0, 255, 255))],
+            [(0.5, Color::rgba(255, 0, 0, 255)), (0.5, Color::rgba(0, 0, 255, 255))],
         ),
     );
     x += 110.0;
@@ -729,14 +729,14 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
         x,
         y,
         "ms one stop",
-        Paint::linear_gradient_stops(0.0, 0.0, 100.0, 0.0, &[(0.5, Color::rgba(255, 0, 0, 255))]),
+        Paint::linear_gradient_stops(0.0, 0.0, 100.0, 0.0, [(0.5, Color::rgba(255, 0, 0, 255))]),
     );
     x += 110.0;
     r(
         x,
         y,
         "ms zero stops",
-        Paint::linear_gradient_stops(0.0, 0.0, 100.0, 0.0, &[]),
+        Paint::linear_gradient_stops(0.0, 0.0, 100.0, 0.0, []),
     );
     x += 110.0;
     r(
@@ -748,7 +748,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             0.0,
-            &[(0.5, Color::rgba(255, 0, 0, 255)), (0.0, Color::rgba(0, 0, 255, 255))],
+            [(0.5, Color::rgba(255, 0, 0, 255)), (0.0, Color::rgba(0, 0, 255, 255))],
         ),
     );
     x += 110.0;
@@ -761,7 +761,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             0.0,
-            &[(0.5, Color::rgba(255, 0, 0, 255)), (0.3, Color::rgba(0, 0, 255, 255))],
+            [(0.5, Color::rgba(255, 0, 0, 255)), (0.3, Color::rgba(0, 0, 255, 255))],
         ),
     );
     x += 110.0;
@@ -774,7 +774,7 @@ fn draw_gradients<T: Renderer>(canvas: &mut Canvas<T>) {
             0.0,
             100.0,
             0.0,
-            &[
+            [
                 (0.5, Color::rgba(255, 0, 0, 255)),
                 (0.6, Color::rgba(0, 255, 0, 255)),
                 (0.3, Color::rgba(0, 0, 255, 255)),

--- a/examples/svg.rs
+++ b/examples/svg.rs
@@ -135,12 +135,12 @@ fn main() {
                 for (path, fill, stroke) in &mut paths {
                     if let Some(fill) = fill {
                         fill.set_anti_alias(true);
-                        canvas.fill_path(path, *fill);
+                        canvas.fill_path(path, fill.clone());
                     }
 
                     if let Some(stroke) = stroke {
                         stroke.set_anti_alias(true);
-                        canvas.stroke_path(path, *stroke);
+                        canvas.stroke_path(path, stroke.clone());
                     }
 
                     if canvas.contains_point(path, mousex, mousey, FillRule::NonZero) {

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -169,7 +169,7 @@ fn main() {
                     size.width as f32 - 10.0,
                     10.0,
                     format!("Scroll to increase / decrease font size. Current: {}", font_size),
-                    paint,
+                    paint.clone(),
                 );
                 #[cfg(feature = "debug_inspector")]
                 let _ = canvas.fill_text(
@@ -231,6 +231,7 @@ fn draw_baselines<T: Renderer>(
         path.line_to(x + 250., y + 0.5);
         canvas.stroke_path(&mut path, Paint::color(Color::rgba(255, 32, 32, 128)));
 
+        let mut paint = paint.clone();
         paint.set_text_baseline(*baseline);
 
         if let Ok(res) = canvas.fill_text(x, y, format!("{} Baseline::{:?}", base_text, baseline), paint) {
@@ -256,6 +257,7 @@ fn draw_alignments<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32, y
     paint.set_font_size(font_size);
 
     for (i, alignment) in alignments.iter().enumerate() {
+        let mut paint = paint.clone();
         paint.set_text_align(*alignment);
 
         if let Ok(res) = canvas.fill_text(x, y + i as f32 * 30.0, format!("Align::{:?}", alignment), paint) {
@@ -272,17 +274,17 @@ fn draw_paragraph<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32, y:
     //paint.set_text_align(Align::Right);
     paint.set_font_size(font_size);
 
-    let font_metrics = canvas.measure_font(paint).expect("Error measuring font");
+    let font_metrics = canvas.measure_font(paint.clone()).expect("Error measuring font");
 
     let width = canvas.width();
     let mut y = y;
 
     let lines = canvas
-        .break_text_vec(width, text, paint)
+        .break_text_vec(width, text, paint.clone())
         .expect("Error while breaking text");
 
     for line_range in lines {
-        if let Ok(_res) = canvas.fill_text(x, y, &text[line_range], paint) {
+        if let Ok(_res) = canvas.fill_text(x, y, &text[line_range], paint.clone()) {
             y += font_metrics.height();
         }
     }
@@ -312,9 +314,14 @@ fn draw_inc_size<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32, y: 
         paint.set_font(&[fonts.sans]);
         paint.set_font_size(i as f32);
 
-        let font_metrics = canvas.measure_font(paint).expect("Error measuring font");
+        let font_metrics = canvas.measure_font(paint.clone()).expect("Error measuring font");
 
-        if let Ok(_res) = canvas.fill_text(x, cursor_y, "The quick brown fox jumps over the lazy dog", paint) {
+        if let Ok(_res) = canvas.fill_text(
+            x,
+            cursor_y,
+            "The quick brown fox jumps over the lazy dog",
+            paint.clone(),
+        ) {
             cursor_y += font_metrics.height();
         }
     }
@@ -325,18 +332,18 @@ fn draw_stroked<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32, y: f
     paint.set_font(&[fonts.bold]);
     paint.set_line_width(12.0);
     paint.set_font_size(72.0);
-    let _ = canvas.stroke_text(x + 5.0, y + 5.0, "RUST", paint);
+    let _ = canvas.stroke_text(x + 5.0, y + 5.0, "RUST", paint.clone());
 
     paint.set_color(Color::black());
     paint.set_line_width(10.0);
-    let _ = canvas.stroke_text(x, y, "RUST", paint);
+    let _ = canvas.stroke_text(x, y, "RUST", paint.clone());
 
     paint.set_line_width(6.0);
     paint.set_color(Color::hex("#B7410E"));
-    let _ = canvas.stroke_text(x, y, "RUST", paint);
+    let _ = canvas.stroke_text(x, y, "RUST", paint.clone());
 
     paint.set_color(Color::white());
-    let _ = canvas.fill_text(x, y, "RUST", paint);
+    let _ = canvas.fill_text(x, y, "RUST", paint.clone());
 }
 
 fn draw_gradient_fill<T: Renderer>(canvas: &mut Canvas<T>, fonts: &Fonts, x: f32, y: f32) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -922,7 +922,7 @@ where
         } else if let Some(paint::GradientColors::MultiStop { stops }) = paint.flavor.gradient_colors() {
             cmd.image = self
                 .gradients
-                .lookup_or_add(*stops, &mut self.images, &mut self.renderer)
+                .lookup_or_add(stops, &mut self.images, &mut self.renderer)
                 .ok();
         }
 
@@ -1077,7 +1077,7 @@ where
         } else if let Some(paint::GradientColors::MultiStop { stops }) = paint.flavor.gradient_colors() {
             cmd.image = self
                 .gradients
-                .lookup_or_add(*stops, &mut self.images, &mut self.renderer)
+                .lookup_or_add(stops, &mut self.images, &mut self.renderer)
                 .ok();
         }
 
@@ -1364,7 +1364,7 @@ where
         } else if let Some(paint::GradientColors::MultiStop { stops }) = paint.flavor.gradient_colors() {
             cmd.image = self
                 .gradients
-                .lookup_or_add(*stops, &mut self.images, &mut self.renderer)
+                .lookup_or_add(stops, &mut self.images, &mut self.renderer)
                 .ok();
         }
 

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -240,8 +240,8 @@ impl Default for GlyphTexture {
 ///
 /// let mut path = Path::new();
 /// path.rounded_rect(10.0, 10.0, 100.0, 100.0, 20.0);
-/// canvas.fill_path(&mut path, &fill_paint);
-/// canvas.stroke_path(&mut path, &stroke_paint);
+/// canvas.fill_path(&mut path, fill_paint);
+/// canvas.stroke_path(&mut path, stroke_paint);
 /// ```
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
@@ -321,7 +321,7 @@ impl Paint {
     ///
     /// let mut path = Path::new();
     /// path.rect(10.0, 10.0, 85.0, 85.0);
-    /// canvas.fill_path(&mut path, &fill_paint);
+    /// canvas.fill_path(&mut path, fill_paint);
     /// ```
     pub fn image(id: ImageId, cx: f32, cy: f32, width: f32, height: f32, angle: f32, alpha: f32) -> Self {
         Paint::with_flavor(PaintFlavor::Image {
@@ -362,7 +362,7 @@ impl Paint {
     /// let bg = Paint::linear_gradient(0.0, 0.0, 0.0, 100.0, Color::rgba(255, 255, 255, 16), Color::rgba(0, 0, 0, 16));
     /// let mut path = Path::new();
     /// path.rounded_rect(0.0, 0.0, 100.0, 100.0, 5.0);
-    /// canvas.fill_path(&mut path, &bg);
+    /// canvas.fill_path(&mut path, bg);
     /// ```
     pub fn linear_gradient(
         start_x: f32,
@@ -400,7 +400,7 @@ impl Paint {
     ///    ]);
     /// let mut path = Path::new();
     /// path.rounded_rect(0.0, 0.0, 100.0, 100.0, 5.0);
-    /// canvas.fill_path(&mut path, &bg);
+    /// canvas.fill_path(&mut path, bg);
     /// ```
     pub fn linear_gradient_stops<Stops>(start_x: f32, start_y: f32, end_x: f32, end_y: f32, stops: Stops) -> Self
     where
@@ -443,7 +443,7 @@ impl Paint {
     ///
     /// let mut path = Path::new();
     /// path.rounded_rect(0.0, 0.0, 100.0, 100.0, 5.0);
-    /// canvas.fill_path(&mut path, &bg);
+    /// canvas.fill_path(&mut path, bg);
     /// ```
     pub fn box_gradient(
         x: f32,
@@ -492,7 +492,7 @@ impl Paint {
     ///
     /// let mut path = Path::new();
     /// path.circle(50.0, 50.0, 20.0);
-    /// canvas.fill_path(&mut path, &bg);
+    /// canvas.fill_path(&mut path, bg);
     /// ```
     pub fn radial_gradient(
         cx: f32,
@@ -541,7 +541,7 @@ impl Paint {
     ///
     /// let mut path = Path::new();
     /// path.circle(50.0, 50.0, 20.0);
-    /// canvas.fill_path(&mut path, &bg);
+    /// canvas.fill_path(&mut path, bg);
     /// ```
     pub fn radial_gradient_stops<Stops>(cx: f32, cy: f32, in_radius: f32, out_radius: f32, stops: Stops) -> Self
     where

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -1,6 +1,8 @@
 // TODO: prefix paint creation functions with make_ or new_
 // so that they are easier to find when autocompleting
 
+use std::rc::Rc;
+
 use crate::geometry::Transform2D;
 use crate::{Align, Baseline, Color, FillRule, FontId, ImageId, LineCap, LineJoin};
 
@@ -29,20 +31,61 @@ impl PartialOrd for GradientStop {
     }
 }
 
-pub(crate) type MultiStopGradient = [GradientStop; 24];
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub(crate) struct MultiStopGradient {
+    shared_stops: Rc<[GradientStop]>,
+    tint: f32,
+}
+
+impl MultiStopGradient {
+    pub(crate) fn get(&self, index: usize) -> GradientStop {
+        let mut stop = self
+            .shared_stops
+            .get(index)
+            .cloned()
+            .unwrap_or_else(|| GradientStop(2.0, Color::black()));
+
+        stop.1.a *= self.tint;
+        stop
+    }
+
+    pub(crate) fn pairs(&self) -> impl Iterator<Item = [GradientStop; 2]> + '_ {
+        self.shared_stops.as_ref().windows(2).map(move |pair| {
+            let mut stops = [pair[0], pair[1]];
+            stops[0].1.a *= self.tint;
+            stops[1].1.a *= self.tint;
+            stops
+        })
+    }
+}
+
+impl Eq for MultiStopGradient {}
+
+impl PartialOrd for MultiStopGradient {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for MultiStopGradient {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        if (&other.shared_stops, other.tint) < (&self.shared_stops, self.tint) {
+            std::cmp::Ordering::Less
+        } else if (&self.shared_stops, self.tint) < (&other.shared_stops, other.tint) {
+            std::cmp::Ordering::Greater
+        } else {
+            std::cmp::Ordering::Equal
+        }
+    }
+}
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub(crate) enum GradientColors {
-    TwoStop {
-        start_color: Color,
-        end_color: Color,
-    },
-    MultiStop {
-        // We support up to 16 stops.
-        stops: MultiStopGradient,
-    },
+    TwoStop { start_color: Color, end_color: Color },
+    MultiStop { stops: MultiStopGradient },
 }
 impl GradientColors {
     fn mul_alpha(&mut self, a: f32) {
@@ -51,10 +94,8 @@ impl GradientColors {
                 start_color.a *= a;
                 end_color.a *= a;
             }
-            GradientColors::MultiStop { stops } => {
-                for stop in stops {
-                    stop.1.a *= a;
-                }
+            GradientColors::MultiStop { stops, .. } => {
+                stops.tint *= a;
             }
         }
     }
@@ -82,20 +123,18 @@ impl GradientColors {
             // Actual multistop gradient. We copy out the stops and then use a stop with a
             // position > 1.0 as a sentinel. GradientStore ignores stop positions > 1.0
             // when synthesizing the gradient texture.
-            let mut out_stops: [GradientStop; 24] = Default::default();
-            for i in 0..24 {
-                if i < stops.len() {
-                    out_stops[i] = GradientStop(stops[i].0, stops[i].1);
-                } else {
-                    out_stops[i] = GradientStop(2.0, Color::black());
-                }
+            let out_stops = stops.iter().map(|(stop, color)| GradientStop(*stop, *color)).collect();
+            GradientColors::MultiStop {
+                stops: MultiStopGradient {
+                    shared_stops: out_stops,
+                    tint: 1.0,
+                },
             }
-            GradientColors::MultiStop { stops: out_stops }
         }
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub(crate) enum PaintFlavor {
     Color(Color),
@@ -324,7 +363,6 @@ impl Paint {
     /// Creates and returns a linear gradient paint with two or more stops.
     ///
     /// The gradient is transformed by the current transform when it is passed to fill_path() or stroke_path().
-    /// If a gradient has more than 24 stops, then only the first 24 stops will be used.
     ///
     /// # Example
     /// ```
@@ -457,7 +495,6 @@ impl Paint {
     ///
     /// Parameters (cx,cy) specify the center, in_radius and out_radius specify the inner and outer radius of the gradient,
     /// colors specifies a list of color stops with offsets. The first offset should be 0.0 and the last offset should be 1.0.
-    /// If a gradient has more than 24 stops, then only the first 24 stops will be used.
     ///
     /// The gradient is transformed by the current transform when it is passed to fill_paint() or stroke_paint().
     ///

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -181,10 +181,10 @@ impl Default for GlyphTexture {
 ///
 /// let mut path = Path::new();
 /// path.rounded_rect(10.0, 10.0, 100.0, 100.0, 20.0);
-/// canvas.fill_path(&mut path, fill_paint);
-/// canvas.stroke_path(&mut path, stroke_paint);
+/// canvas.fill_path(&mut path, &fill_paint);
+/// canvas.stroke_path(&mut path, &stroke_paint);
 /// ```
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub struct Paint {
     pub(crate) flavor: PaintFlavor,
@@ -262,7 +262,7 @@ impl Paint {
     ///
     /// let mut path = Path::new();
     /// path.rect(10.0, 10.0, 85.0, 85.0);
-    /// canvas.fill_path(&mut path, fill_paint);
+    /// canvas.fill_path(&mut path, &fill_paint);
     /// ```
     pub fn image(id: ImageId, cx: f32, cy: f32, width: f32, height: f32, angle: f32, alpha: f32) -> Self {
         Paint::with_flavor(PaintFlavor::Image {
@@ -303,7 +303,7 @@ impl Paint {
     /// let bg = Paint::linear_gradient(0.0, 0.0, 0.0, 100.0, Color::rgba(255, 255, 255, 16), Color::rgba(0, 0, 0, 16));
     /// let mut path = Path::new();
     /// path.rounded_rect(0.0, 0.0, 100.0, 100.0, 5.0);
-    /// canvas.fill_path(&mut path, bg);
+    /// canvas.fill_path(&mut path, &bg);
     /// ```
     pub fn linear_gradient(
         start_x: f32,
@@ -342,7 +342,7 @@ impl Paint {
     ///    ]);
     /// let mut path = Path::new();
     /// path.rounded_rect(0.0, 0.0, 100.0, 100.0, 5.0);
-    /// canvas.fill_path(&mut path, bg);
+    /// canvas.fill_path(&mut path, &bg);
     /// ```
     pub fn linear_gradient_stops(start_x: f32, start_y: f32, end_x: f32, end_y: f32, stops: &[(f32, Color)]) -> Self {
         Paint::with_flavor(PaintFlavor::LinearGradient {
@@ -382,7 +382,7 @@ impl Paint {
     ///
     /// let mut path = Path::new();
     /// path.rounded_rect(0.0, 0.0, 100.0, 100.0, 5.0);
-    /// canvas.fill_path(&mut path, bg);
+    /// canvas.fill_path(&mut path, &bg);
     /// ```
     pub fn box_gradient(
         x: f32,
@@ -431,7 +431,7 @@ impl Paint {
     ///
     /// let mut path = Path::new();
     /// path.circle(50.0, 50.0, 20.0);
-    /// canvas.fill_path(&mut path, bg);
+    /// canvas.fill_path(&mut path, &bg);
     /// ```
     pub fn radial_gradient(
         cx: f32,
@@ -481,7 +481,7 @@ impl Paint {
     ///
     /// let mut path = Path::new();
     /// path.circle(50.0, 50.0, 20.0);
-    /// canvas.fill_path(&mut path, bg);
+    /// canvas.fill_path(&mut path, &bg);
     /// ```
     pub fn radial_gradient_stops(cx: f32, cy: f32, in_radius: f32, out_radius: f32, stops: &[(f32, Color)]) -> Self {
         Paint::with_flavor(PaintFlavor::RadialGradient {

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -99,37 +99,57 @@ impl GradientColors {
             }
         }
     }
-    fn from_stops(stops: &[(f32, Color)]) -> GradientColors {
-        if stops.is_empty() {
-            // No stops, we use black.
-            GradientColors::TwoStop {
-                start_color: Color::black(),
-                end_color: Color::black(),
+    fn from_stops<Stops>(stops: Stops) -> GradientColors
+    where
+        Stops: IntoIterator<Item = (f32, Color)>,
+    {
+        let mut stops = stops.into_iter();
+        let first_stop = match stops.next() {
+            Some(stop) => stop,
+            None => {
+                // No stops, we use black.
+                return GradientColors::TwoStop {
+                    start_color: Color::black(),
+                    end_color: Color::black(),
+                };
             }
-        } else if stops.len() == 1 {
-            // One stop devolves to a solid color fill (but using the gradient shader variation).
-            GradientColors::TwoStop {
-                start_color: stops[0].1,
-                end_color: stops[0].1,
+        };
+        let second_stop = match stops.next() {
+            Some(stop) => stop,
+            None => {
+                // One stop devolves to a solid color fill (but using the gradient shader variation).
+                return GradientColors::TwoStop {
+                    start_color: first_stop.1,
+                    end_color: first_stop.1,
+                };
             }
-        } else if stops.len() == 2 && stops[0].0 <= 0.0 && stops[1].0 >= 1.0 {
+        };
+
+        let maybe_third_stop = stops.next();
+
+        if maybe_third_stop.is_none() && first_stop.0 <= 0.0 && second_stop.0 >= 1.0 {
             // Two stops takes the classic gradient path, so long as the stop positions are at
             // the extents (if the stop positions are inset then we'll fill to them).
-            GradientColors::TwoStop {
-                start_color: stops[0].1,
-                end_color: stops[1].1,
-            }
-        } else {
-            // Actual multistop gradient. We copy out the stops and then use a stop with a
-            // position > 1.0 as a sentinel. GradientStore ignores stop positions > 1.0
-            // when synthesizing the gradient texture.
-            let out_stops = stops.iter().map(|(stop, color)| GradientStop(*stop, *color)).collect();
-            GradientColors::MultiStop {
-                stops: MultiStopGradient {
-                    shared_stops: out_stops,
-                    tint: 1.0,
-                },
-            }
+            return GradientColors::TwoStop {
+                start_color: first_stop.1,
+                end_color: second_stop.1,
+            };
+        }
+
+        // Actual multistop gradient. We copy out the stops and then use a stop with a
+        // position > 1.0 as a sentinel. GradientStore ignores stop positions > 1.0
+        // when synthesizing the gradient texture.
+        let out_stops = [first_stop, second_stop]
+            .into_iter()
+            .chain(maybe_third_stop)
+            .chain(stops)
+            .map(|(stop, color)| GradientStop(stop, color))
+            .collect();
+        GradientColors::MultiStop {
+            stops: MultiStopGradient {
+                shared_stops: out_stops,
+                tint: 1.0,
+            },
         }
     }
 }
@@ -373,7 +393,7 @@ impl Paint {
     /// let bg = Paint::linear_gradient_stops(
     ///    0.0, 0.0,
     ///    0.0, 100.0,
-    ///    &[
+    ///    [
     ///         (0.0, Color::rgba(255, 255, 255, 16)),
     ///         (0.5, Color::rgba(0, 0, 0, 16)),
     ///         (1.0, Color::rgba(255, 0, 0, 16))
@@ -382,7 +402,10 @@ impl Paint {
     /// path.rounded_rect(0.0, 0.0, 100.0, 100.0, 5.0);
     /// canvas.fill_path(&mut path, &bg);
     /// ```
-    pub fn linear_gradient_stops(start_x: f32, start_y: f32, end_x: f32, end_y: f32, stops: &[(f32, Color)]) -> Self {
+    pub fn linear_gradient_stops<Stops>(start_x: f32, start_y: f32, end_x: f32, end_y: f32, stops: Stops) -> Self
+    where
+        Stops: IntoIterator<Item = (f32, Color)>,
+    {
         Paint::with_flavor(PaintFlavor::LinearGradient {
             start_x,
             start_y,
@@ -509,7 +532,7 @@ impl Paint {
     ///    50.0,
     ///    18.0,
     ///    24.0,
-    ///    &[
+    ///    [
     ///         (0.0, Color::rgba(0, 0, 0, 128)),
     ///         (0.5, Color::rgba(0, 0, 128, 128)),
     ///         (1.0, Color::rgba(0, 128, 0, 128))
@@ -520,7 +543,10 @@ impl Paint {
     /// path.circle(50.0, 50.0, 20.0);
     /// canvas.fill_path(&mut path, &bg);
     /// ```
-    pub fn radial_gradient_stops(cx: f32, cy: f32, in_radius: f32, out_radius: f32, stops: &[(f32, Color)]) -> Self {
+    pub fn radial_gradient_stops<Stops>(cx: f32, cy: f32, in_radius: f32, out_radius: f32, stops: Stops) -> Self
+    where
+        Stops: IntoIterator<Item = (f32, Color)>,
+    {
         Paint::with_flavor(PaintFlavor::RadialGradient {
             cx,
             cy,

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -14,7 +14,7 @@ use rgb::RGBA8;
 use crate::{
     renderer::{GlyphTexture, ImageId, Vertex},
     BlendFactor, Color, CompositeOperationState, ErrorKind, FillRule, ImageFilter, ImageInfo, ImageSource, ImageStore,
-    Scissor,
+    Scissor, Transform2D,
 };
 
 use glow::HasContext;
@@ -560,7 +560,7 @@ impl OpenGl {
             0.,
             1.,
         );
-        let mut blur_params = Params::new(images, &image_paint, &Scissor::default(), 0., 0., 0.);
+        let mut blur_params = Params::new(images, &image_paint, &Scissor::default(), &Transform2D::default(), 0., 0., 0., 1.);
         blur_params.shader_type = ShaderType::FilterImage;
 
         let gauss_coeff_x = 1. / ((2. * std::f32::consts::PI).sqrt() * sigma);

--- a/src/renderer/params.rs
+++ b/src/renderer/params.rs
@@ -71,7 +71,7 @@ impl Params {
 
         let inv_transform;
 
-        match paint.flavor {
+        match &paint.flavor {
             PaintFlavor::Color(color) => {
                 let color = color.premultiplied().to_array();
                 params.inner_col = color;
@@ -88,13 +88,13 @@ impl Params {
                 angle,
                 tint,
             } => {
-                let image_info = match images.info(id) {
+                let image_info = match images.info(*id) {
                     Some(info) => info,
                     None => return params,
                 };
 
-                params.extent[0] = width;
-                params.extent[1] = height;
+                params.extent[0] = *width;
+                params.extent[1] = *height;
 
                 let color = tint;
 
@@ -102,8 +102,8 @@ impl Params {
                 params.outer_col = color.premultiplied().to_array();
 
                 let mut transform = Transform2D::identity();
-                transform.rotate(angle);
-                transform.translate(cx, cy);
+                transform.rotate(*angle);
+                transform.translate(*cx, *cy);
                 transform.multiply(&paint.transform);
 
                 if image_info.flags().contains(ImageFlags::FLIP_Y) {
@@ -194,8 +194,8 @@ impl Params {
 
                 params.extent[0] = width * 0.5;
                 params.extent[1] = height * 0.5;
-                params.radius = radius;
-                params.feather = feather;
+                params.radius = *radius;
+                params.feather = *feather;
                 match colors {
                     GradientColors::TwoStop { start_color, end_color } => {
                         params.inner_col = start_color.premultiplied().to_array();
@@ -217,7 +217,7 @@ impl Params {
                 let r = (in_radius + out_radius) * 0.5;
                 let f = out_radius - in_radius;
 
-                let mut transform = Transform2D::new_translation(cx, cy);
+                let mut transform = Transform2D::new_translation(*cx, *cy);
                 transform.multiply(&paint.transform);
                 inv_transform = transform.inversed();
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -236,14 +236,20 @@ impl TextContext {
     }
 
     /// Returns information on how the provided text will be drawn with the specified paint.
-    pub fn measure_text<S: AsRef<str>>(&self, x: f32, y: f32, text: S, paint: Paint) -> Result<TextMetrics, ErrorKind> {
+    pub fn measure_text<S: AsRef<str>>(
+        &self,
+        x: f32,
+        y: f32,
+        text: S,
+        paint: &Paint,
+    ) -> Result<TextMetrics, ErrorKind> {
         self.0.as_ref().borrow_mut().measure_text(x, y, text, paint)
     }
 
     /// Returns the maximum index-th byte of text that will fit inside max_width.
     ///
     /// The retuned index will always lie at the start and/or end of a UTF-8 code point sequence or at the start or end of the text
-    pub fn break_text<S: AsRef<str>>(&self, max_width: f32, text: S, paint: Paint) -> Result<usize, ErrorKind> {
+    pub fn break_text<S: AsRef<str>>(&self, max_width: f32, text: S, paint: &Paint) -> Result<usize, ErrorKind> {
         self.0.as_ref().borrow_mut().break_text(max_width, text, paint)
     }
 
@@ -252,13 +258,13 @@ impl TextContext {
         &self,
         max_width: f32,
         text: S,
-        paint: Paint,
+        paint: &Paint,
     ) -> Result<Vec<Range<usize>>, ErrorKind> {
         self.0.as_ref().borrow_mut().break_text_vec(max_width, text, paint)
     }
 
     /// Returns font metrics for a particular Paint.
-    pub fn measure_font(&self, paint: Paint) -> Result<FontMetrics, ErrorKind> {
+    pub fn measure_font(&self, paint: &Paint) -> Result<FontMetrics, ErrorKind> {
         self.0.as_ref().borrow_mut().measure_font(paint)
     }
 
@@ -419,13 +425,13 @@ impl TextContextImpl {
         x: f32,
         y: f32,
         text: S,
-        paint: Paint,
+        paint: &Paint,
     ) -> Result<TextMetrics, ErrorKind> {
-        shape(x, y, self, &paint, text.as_ref(), None)
+        shape(x, y, self, paint, text.as_ref(), None)
     }
 
-    pub fn break_text<S: AsRef<str>>(&mut self, max_width: f32, text: S, paint: Paint) -> Result<usize, ErrorKind> {
-        let layout = shape(0.0, 0.0, self, &paint, text.as_ref(), Some(max_width))?;
+    pub fn break_text<S: AsRef<str>>(&mut self, max_width: f32, text: S, paint: &Paint) -> Result<usize, ErrorKind> {
+        let layout = shape(0.0, 0.0, self, paint, text.as_ref(), Some(max_width))?;
 
         Ok(layout.final_byte_index)
     }
@@ -434,7 +440,7 @@ impl TextContextImpl {
         &mut self,
         max_width: f32,
         text: S,
-        paint: Paint,
+        paint: &Paint,
     ) -> Result<Vec<Range<usize>>, ErrorKind> {
         let text = text.as_ref();
 
@@ -458,7 +464,7 @@ impl TextContextImpl {
         Ok(res)
     }
 
-    pub fn measure_font(&mut self, paint: Paint) -> Result<FontMetrics, ErrorKind> {
+    pub fn measure_font(&mut self, paint: &Paint) -> Result<FontMetrics, ErrorKind> {
         if let Some(Some(id)) = paint.font_ids.get(0) {
             if let Some(font) = self.font(*id) {
                 return Ok(font.metrics(paint.font_size));
@@ -1036,9 +1042,9 @@ impl GlyphAtlas {
                     canvas.scale(scale, scale);
 
                     if mode == RenderMode::Stroke {
-                        canvas.stroke_path(path, mask_paint);
+                        canvas.stroke_path(path, mask_paint.clone());
                     } else {
-                        canvas.fill_path(path, mask_paint);
+                        canvas.fill_path(path, mask_paint.clone());
                     }
 
                     canvas.restore();
@@ -1168,11 +1174,10 @@ impl GlyphAtlas {
 pub(crate) fn render_direct<T: Renderer>(
     canvas: &mut Canvas<T>,
     text_layout: &TextMetrics,
-    paint: &Paint,
+    mut paint: Paint,
     mode: RenderMode,
     invscale: f32,
 ) -> Result<(), ErrorKind> {
-    let mut paint = *paint;
     paint.set_fill_rule(FillRule::EvenOdd);
 
     let text_context = canvas.text_context.clone();
@@ -1199,6 +1204,7 @@ pub(crate) fn render_direct<T: Renderer>(
 
         canvas.save();
 
+        let mut paint = paint.clone();
         if mode == RenderMode::Stroke && !scaled {
             paint.line_width /= scale;
             scaled = true;
@@ -1215,7 +1221,7 @@ pub(crate) fn render_direct<T: Renderer>(
                 if mode == RenderMode::Stroke {
                     canvas.stroke_path(path, paint);
                 } else {
-                    canvas.fill_path(path, paint);
+                    canvas.fill_path(path, paint.clone());
                 }
             }
             #[cfg(feature = "image-loading")]

--- a/src/text.rs
+++ b/src/text.rs
@@ -1042,9 +1042,9 @@ impl GlyphAtlas {
                     canvas.scale(scale, scale);
 
                     if mode == RenderMode::Stroke {
-                        canvas.stroke_path(path, mask_paint.clone());
+                        canvas.stroke_path(path, &mask_paint);
                     } else {
-                        canvas.fill_path(path, mask_paint.clone());
+                        canvas.fill_path(path, &mask_paint);
                     }
 
                     canvas.restore();
@@ -1219,9 +1219,9 @@ pub(crate) fn render_direct<T: Renderer>(
         match glyph_rendering {
             GlyphRendering::RenderAsPath(path) => {
                 if mode == RenderMode::Stroke {
-                    canvas.stroke_path(path, paint);
+                    canvas.stroke_path(path, &paint);
                 } else {
-                    canvas.fill_path(path, paint.clone());
+                    canvas.fill_path(path, &paint);
                 }
             }
             #[cfg(feature = "image-loading")]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -175,7 +175,7 @@ fn text_measure_without_canvas() {
     test_paint.set_font_size(16.);
 
     let metrics = text_context
-        .measure_text(0., 0., "Hello World", test_paint)
+        .measure_text(0., 0., "Hello World", &test_paint)
         .expect("text shaping failed unexpectedly");
 
     assert_eq!(metrics.width().ceil(), 83.);
@@ -195,7 +195,7 @@ fn font_measure_without_canvas() {
     test_paint.set_font_size(16.);
 
     let metrics = text_context
-        .measure_font(test_paint)
+        .measure_font(&test_paint)
         .expect("font measuring failed unexpectedly");
 
     assert_eq!(metrics.ascender().ceil(), 17.);
@@ -216,7 +216,7 @@ fn break_text_without_canvas() {
     let text = "Multiple Lines Broken";
 
     let breaks = text_context
-        .break_text_vec(60., text, test_paint)
+        .break_text_vec(60., text, &test_paint)
         .expect("text shaping failed unexpectedly");
 
     assert_eq!(


### PR DESCRIPTION
I've managed to do it, but was in a bit of a hurry and could only test with the gradient and demo examples. There's no more need for cloning the paint and by using impl Borrow it can be passed by both value and a reference to stroke and fill path, so it shouldn't be a breaking change. 

But to reiterate, I'm not an expert on idiomatic APIs either, and using just &Paint or making the cloning explicit like in your PR may be a better solution because I'm not sure if Borrow was intended for that. I think you have one of the biggest codebases using femtovg so I'm leaving it up to you, or we can continue this discussion in https://github.com/femtovg/femtovg/pull/101